### PR TITLE
Persist settings correctly and support multiple tunneling paths

### DIFF
--- a/dropship/dropship/src/core/Dashboard.cpp
+++ b/dropship/dropship/src/core/Dashboard.cpp
@@ -2,7 +2,9 @@
 
 #include "core/Dashboard.h"
 
+
 extern std::unique_ptr<Settings> g_settings;
+extern std::unique_ptr<core::tunneling::Tunneling> g_tunneling;
 
 Dashboard::Dashboard()
 {
@@ -70,10 +72,12 @@ Dashboard::Dashboard()
 			.title = "tunneling configuration",
 			//.tooltip = "default: automatic\n\nThe location of Overwatch.exe must be known\nin order to enable tunneling. in most situations,\ntunneling should automatically locate your\nOverwatch.exe application. if automatically\nfinding it didn't work, a manual configuration popup will appear when you open the application. this can be ignored, but will show up again every launch unless you disable \"tunneling\" in options  • since tunneling only blocks traffic per - application, if you notice dropship is not working at all(you still connect to blocked servers), you may have selected an incorrect Overwatch.exe.you can always disable tunneling if you choose to. ",
 			.action = [this]() {
-				g_settings->setConfigTunnelingPath(std::nullopt);
 				if (!g_settings->getAppSettings().options.tunneling)
 				{
 					(*g_settings).toggleOptionTunneling();
+				}
+				if (g_tunneling) {
+					g_tunneling->openExplainer();
 				}
 			},
 			.external = false,

--- a/dropship/dropship/src/core/Firewall.cpp
+++ b/dropship/dropship/src/core/Firewall.cpp
@@ -20,9 +20,6 @@ Firewall::Firewall()
 
 
 	/*
-	
-	legacy: always remove stormy.gg/dropship
-	new group name: stormy/dropship
 
 	legacy: always remove stormy.gg/dropship
 	new group name: stormy/dropship
@@ -32,7 +29,10 @@ Firewall::Firewall()
 
 	legacy: always remove stormy.gg/dropship
 	new group name: stormy/dropship
-	
+
+	legacy: always remove stormy.gg/dropship
+	new group name: stormy/dropship
+
 	*/
 
 }
@@ -55,92 +55,98 @@ void Firewall::_queryNetworkStatus() {
 
 }
 
-void Firewall::tryWriteSettingsToFirewall(std::string data, std::string block, std::optional<std::filesystem::path> tunneling_path) {
+void Firewall::tryWriteSettingsToFirewall(std::string data, std::string block, std::set<std::filesystem::path> tunneling_paths) {
+	// Delete all existing rules in the dropship group
+	util::win_firewall::removeAllRulesInGroup(this->__group_name);
 
-	println("storage: {} / 1024", data.length());
+	// Always create rules to persist the Description (settings data).
+	// If there's nothing to block, create disabled rules.
+	BSTR description_bstr = SysAllocStringByteLen(data.data(), (UINT)data.length());
 
-	util::win_firewall::forFirewallRulesInGroup(this->__group_name, [&data, &block, &tunneling_path](const CComPtr<INetFwRule>& FwRule, const CComPtr<INetFwRules>& rules) {
+	bool has_block = !block.empty();
+	CComBSTR blocked_addresses(block.c_str());
 
-		CComBSTR description (data.c_str());
-		if (SUCCEEDED(FwRule->put_Description(description)))
+	int rule_index = 0;
+	for (auto& path : tunneling_paths) {
+		CComBSTR rule_name(rule_index == 0 ? L"stormy/dropship" :
+			(std::wstring(L"stormy/dropship ") + std::to_wstring(rule_index + 1)).c_str());
+		CComBSTR group_name(this->__group_name.c_str());
+
+		CComPtr<INetFwRule> pFwRule;
+		if (FAILED(CoCreateInstance(__uuidof(NetFwRule), nullptr, CLSCTX_INPROC_SERVER, __uuidof(INetFwRule), (void**)&pFwRule)))
 		{
-			printf("description write successful\n");
+			printf("CoCreateInstance for Firewall Rule failed\n");
+			continue;
 		}
 
-		if (tunneling_path)
+		pFwRule->put_Name(rule_name);
+		if (description_bstr) pFwRule->put_Description(description_bstr);
+		CComBSTR application_name(path.wstring().c_str());
+		pFwRule->put_ApplicationName(application_name);
+		pFwRule->put_Protocol(NET_FW_IP_PROTOCOL_ANY);
+		if (has_block) pFwRule->put_RemoteAddresses(blocked_addresses);
+		pFwRule->put_Direction(NET_FW_RULE_DIR_OUT);
+		pFwRule->put_Grouping(group_name);
+		pFwRule->put_Profiles(NET_FW_PROFILE2_ALL);
+		pFwRule->put_Action(NET_FW_ACTION_BLOCK);
+		pFwRule->put_Enabled(has_block ? VARIANT_TRUE : VARIANT_FALSE);
+
+		util::win_firewall::firewallRulesPredicate([&pFwRule](const CComPtr<INetFwRules>& FwRules) {
+			if (FAILED(FwRules->Add(pFwRule))) {
+				printf("Firewall Rule Add failed\n");
+			}
+		});
+
+		rule_index++;
+	}
+
+	// If no per-app paths, create a single global rule
+	if (tunneling_paths.empty()) {
+		CComBSTR rule_name(L"stormy/dropship");
+		CComBSTR group_name(this->__group_name.c_str());
+
+		CComPtr<INetFwRule> pFwRule;
+		if (FAILED(CoCreateInstance(__uuidof(NetFwRule), nullptr, CLSCTX_INPROC_SERVER, __uuidof(INetFwRule), (void**)&pFwRule)))
 		{
-			CComBSTR application_name (tunneling_path.value().c_str());
-			if (SUCCEEDED(FwRule->put_ApplicationName(application_name)))
-			{
-				printf("application_name write successful\n");
-			}
-		}
-		else
-		{
-			if (SUCCEEDED(FwRule->put_ApplicationName(NULL)))
-			{
-				printf("application_name delete successful\n");
-			}
-		}
-
-
-		/*
-			. if no blocks, unblock and set scope to ""
-			. if blocks, concat and block
-
-		*/
-
-		if (block.empty()) {
-			println("nothing blocked, unblocking..");
-
-			if (FAILED(FwRule->put_Enabled(VARIANT_FALSE)))
-			{
-				printf("unblock failed\n");
-			}
+			printf("CoCreateInstance for Firewall Rule failed\n");
 		}
 		else {
+			pFwRule->put_Name(rule_name);
+			if (description_bstr) pFwRule->put_Description(description_bstr);
+			pFwRule->put_Protocol(NET_FW_IP_PROTOCOL_ANY);
+			if (has_block) pFwRule->put_RemoteAddresses(blocked_addresses);
+			pFwRule->put_Direction(NET_FW_RULE_DIR_OUT);
+			pFwRule->put_Grouping(group_name);
+			pFwRule->put_Profiles(NET_FW_PROFILE2_ALL);
+			pFwRule->put_Action(NET_FW_ACTION_BLOCK);
+			pFwRule->put_Enabled(has_block ? VARIANT_TRUE : VARIANT_FALSE);
 
-			CComBSTR blocked_addresses (block.c_str());
-
-			if (FAILED(FwRule->put_RemoteAddresses(blocked_addresses)))
-			{
-				printf("block addresses failed\n");
-			}
-			else {
-				/* !important make sure remote addresses are not blank. */
-				/* !important otherwise this blocks all internet traffic permanently */
-				if (FAILED(FwRule->put_Enabled(VARIANT_TRUE)))
-				{
-					printf("block failed\n");
+			util::win_firewall::firewallRulesPredicate([&pFwRule](const CComPtr<INetFwRules>& FwRules) {
+				if (FAILED(FwRules->Add(pFwRule))) {
+					printf("Firewall Rule Add failed\n");
 				}
-			}
+			});
 		}
+	}
 
-
-	});
+	if (description_bstr) SysFreeString(description_bstr);
 }
 
-std::optional<std::string> Firewall::tryFetchSettingsFromFirewall() {
+	std::optional<std::string> Firewall::tryFetchSettingsFromFirewall() {
 
 	std::optional<std::string> loaded_settings = std::nullopt;
 
 	util::win_firewall::forFirewallRulesInGroup(this->__group_name, [&loaded_settings](const CComPtr<INetFwRule>& FwRule, const CComPtr<INetFwRules>& rules) {
 
-		//USES_CONVERSION;
 		CComBSTR description;
 		if (SUCCEEDED(FwRule->get_Description(&description)) && description)
 		{
-
-			/*const auto ws = std::wstring(description, SysStringLen(description));
-			std::string s(ws.begin(), ws.end());*/
-
-			// web std::string sTarget = OLE2A(bstrSource);
-
-			CW2A s (description);
-
-			loaded_settings = std::make_optional<std::string>(s);
-
-			println("patch chars: {}/1024", description.ByteLength());
+			UINT byte_len = SysStringByteLen(description);
+			if (byte_len > 0)
+			{
+				std::string s(reinterpret_cast<const char*>(static_cast<BSTR>(description)), byte_len);
+				loaded_settings = std::make_optional<std::string>(s);
+			}
 		}	
 	});
 
@@ -150,7 +156,7 @@ std::optional<std::string> Firewall::tryFetchSettingsFromFirewall() {
 
 
 /*
-	.. currently, ensure a single rule exists
+	.. ensure a single rule exists
 	.. in future, may want to ensure a single out and single in rule exist
 */
 void Firewall::_validateRules() {
@@ -159,80 +165,44 @@ void Firewall::_validateRules() {
 	util::timer::Timer timer("_validateRules");
 #endif
 
-	int c = 0;
+	/* legacy - remove old group safely */
+	util::win_firewall::removeAllRulesInGroup(this->__group_name_legacy);
 
-	/* legacy */
-	{	
-		/* delete all stormy.gg/dropship blocks */
-		util::win_firewall::forFirewallRulesInGroup(this->__group_name_legacy, [&c](const CComPtr<INetFwRule>& FwRule, const CComPtr<INetFwRules>& FwRules) {
-			CComBSTR ruleName;
-			FwRule->get_Name(&ruleName);
-			FwRules->Remove(ruleName);
-		});
-	}
-
-	util::win_firewall::forFirewallRulesInGroup(this->__group_name, [&c](const CComPtr<INetFwRule>& FwRule, const CComPtr<INetFwRules>& rules) {
-		c ++;
-	});
-
-	if (c != 1) {
-		// delete all rules
-		util::win_firewall::forFirewallRulesInGroup(this->__group_name, [&c](const CComPtr<INetFwRule>& FwRule, const CComPtr<INetFwRules>& FwRules) {
-			CComBSTR ruleName;
-			if (FAILED(FwRule->get_Name(&ruleName)) && ruleName)
-			{
-				printf("failed to get rule name\n");
-			}
-			if (FAILED(FwRules->Remove(ruleName)))
-			{
-				printf("failed to delete rule\n");
-			};
+	/* ensure at least one rule exists in the group (for settings storage) */
+	{
+		int c = 0;
+		util::win_firewall::forFirewallRulesInGroup(this->__group_name, [&c](const CComPtr<INetFwRule>&, const CComPtr<INetFwRules>&) {
+			c++;
 		});
 
-
-		// add single rule
-		util::win_firewall::firewallRulesPredicate([this](const CComPtr<INetFwRules>& FwRules)
-		{
-			CComBSTR rule_name ("stormy/dropship");
-			CComBSTR group_name (this->__group_name.c_str());
-			//CComBSTR remote_addresses ("");
-			NET_FW_RULE_DIRECTION_ dir = NET_FW_RULE_DIR_OUT;
-			NET_FW_PROFILE_TYPE2_ profile = NET_FW_PROFILE2_ALL;
-
-			CComPtr<INetFwRule> pFwRule;
-			if (FAILED(CoCreateInstance(__uuidof(NetFwRule), nullptr, CLSCTX_INPROC_SERVER, __uuidof(INetFwRule), (void**)&pFwRule)))
+		if (c == 0) {
+			util::win_firewall::firewallRulesPredicate([this](const CComPtr<INetFwRules>& FwRules)
 			{
-				printf("CoCreateInstance for Firewall Rule failed \n");
-			}
+				CComBSTR rule_name("stormy/dropship");
+				CComBSTR group_name(this->__group_name.c_str());
+				NET_FW_RULE_DIRECTION_ dir = NET_FW_RULE_DIR_OUT;
+				NET_FW_PROFILE_TYPE2_ profile = NET_FW_PROFILE2_ALL;
 
-			// Populate the Firewall Rule object
-			pFwRule->put_Name(rule_name);
-			//pFwRule->put_Description(bstrRuleDescription);
+				CComPtr<INetFwRule> pFwRule;
+				if (FAILED(CoCreateInstance(__uuidof(NetFwRule), nullptr, CLSCTX_INPROC_SERVER, __uuidof(INetFwRule), (void**)&pFwRule)))
+				{
+					printf("CoCreateInstance for Firewall Rule failed\n");
+				}
+				else {
+					pFwRule->put_Name(rule_name);
+					pFwRule->put_Protocol(NET_FW_IP_PROTOCOL_ANY);
+					pFwRule->put_Direction(dir);
+					pFwRule->put_Grouping(group_name);
+					pFwRule->put_Profiles(profile);
+					pFwRule->put_Action(NET_FW_ACTION_BLOCK);
+					pFwRule->put_Enabled(VARIANT_FALSE);
 
-
-
-
-			// TODO utfdecode
-			//pFwRule->put_ApplicationName(bstrRuleApplication);
-
-
-
-
-			pFwRule->put_Protocol(NET_FW_IP_PROTOCOL_ANY);
-			//pFwRule->put_RemoteAddresses(remote_addresses);
-			pFwRule->put_Direction(dir);
-			pFwRule->put_Grouping(group_name);
-			pFwRule->put_Profiles(profile);
-			pFwRule->put_Action(NET_FW_ACTION_BLOCK);
-			pFwRule->put_Enabled(VARIANT_FALSE);
-
-			// Add the Firewall Rule
-			if (FAILED(FwRules->Add(pFwRule)))
-			{
-				printf("Firewall Rule Add failed: \n");
-			}
-
-			else printf("Firewall Rule Added\n");
-		});
+					if (FAILED(FwRules->Add(pFwRule)))
+						printf("Firewall Rule Add failed\n");
+					else
+						printf("Firewall Rule Added\n");
+				}
+			});
+		}
 	}
 }

--- a/dropship/dropship/src/core/Firewall.h
+++ b/dropship/dropship/src/core/Firewall.h
@@ -28,7 +28,7 @@ class Firewall
 
 		void render();
 
-		void tryWriteSettingsToFirewall(std::string data, std::string block, std::optional<std::filesystem::path> tunneling_path);
+		void tryWriteSettingsToFirewall(std::string data, std::string block, std::set<std::filesystem::path> tunneling_paths);
 		std::optional<std::string> tryFetchSettingsFromFirewall();
 
 	private:

--- a/dropship/dropship/src/core/Settings.cpp
+++ b/dropship/dropship/src/core/Settings.cpp
@@ -12,6 +12,12 @@ extern ImFont* font_subtitle;
 namespace dropship::settings {
 	void to_json(json& j, const dropship_app_settings& p) {
 
+		// Convert tunneling_paths (std::filesystem::path) to strings for JSON
+		std::vector<std::string> path_strings;
+		for (auto& path : p.config.tunneling_paths) {
+			path_strings.push_back(path.string());
+		}
+
 		j = json {
 			{"options", {
 				{ "auto_update", p.options.auto_update },
@@ -20,13 +26,9 @@ namespace dropship::settings {
 			}},
 			{"config", {
 				{ "blocked_endpoints", p.config.blocked_endpoints },
+				{ "tunneling_paths", path_strings },
 			}},
 		};
-
-		if (p.config.tunneling_path)
-		{
-			j["/config/tunneling_path"_json_pointer] = p.config.tunneling_path.value();
-		}
 	}
 	
 	json strip_diff_dropship_app_settings(const json& j_default, const json& j) {
@@ -45,19 +47,12 @@ namespace dropship::settings {
 
 			/* vector<string> */
 			"/config/blocked_endpoints"_json_pointer,
+			"/config/tunneling_paths"_json_pointer,
 		};
 
 		for (auto& p : compare)
 			if (j.contains(p) && j_default.at(p) != j.at(p))
 				result[p] = j.at(p);
-
-
-		/* optional values */
-		const auto p = "/config/tunneling_path"_json_pointer;
-		if (j.contains(p))
-		{
-			result[p] = j.at(p);
-		}
 
 		return result;
 	}
@@ -70,11 +65,12 @@ namespace dropship::settings {
 
 		if (j.contains("/config/blocked_endpoints"_json_pointer)) j.at("/config/blocked_endpoints"_json_pointer).get_to(p.config.blocked_endpoints);
 
-		/* optional values */
-		//if (j.contains("/config/tunneling_path"_json_pointer)) j.at("/config/tunneling_path"_json_pointer).get_to(p.config.tunneling_path);
-		const auto pt = "/config/tunneling_path"_json_pointer;
-		if (j.contains(pt)) {
-			p.config.tunneling_path = std::make_optional<std::filesystem::path>(j.at(pt));
+		if (j.contains("/config/tunneling_paths"_json_pointer)) {
+			std::vector<std::string> path_strings = j.at("/config/tunneling_paths"_json_pointer);
+			p.config.tunneling_paths.clear();
+			for (auto& s : path_strings) {
+				p.config.tunneling_paths.insert(std::filesystem::path(s));
+			}
 		}
 	}
 }
@@ -175,15 +171,9 @@ std::optional<json> Settings::readStoragePatch__win_firewall() {
 void Settings::tryLoadSettingsFromStorage() {
 	auto loaded_settings = this->readStoragePatch();
 	if (loaded_settings) {
-
 		try {
 			json settings = this->__default_dropship_app_settings;
-
-			//settings.merge_patch(loaded_settings.value());
-
-			/* merge obects: false */
 			settings.update(loaded_settings.value(), false);
-
 			this->_dropship_app_settings = settings;
 		}
 		catch (json::exception& e) {
@@ -223,19 +213,16 @@ void Settings::tryWriteSettingsToStorage(bool force) {
 
 		json stripped = dropship::settings::strip_diff_dropship_app_settings(this->__default_dropship_app_settings, this->_dropship_app_settings);
 
-		if (stripped.is_null())
+		if (stripped.is_null() || stripped.empty())
 		{
 			stripped = this->__default_dropship_app_settings;
 		}
-
-		// throws error
-		//println("writing: {}", stripped.dump(4));
 
 		/* note: diff calcuated in to_json defined above */
 		auto packed = json::to_msgpack(stripped);
 		std::string s(packed.begin(), packed.end());
 
-		(*g_firewall).tryWriteSettingsToFirewall(s, this->getAllBlockedAddresses(), this->getAppSettings().options.tunneling ? this->getAppSettings().config.tunneling_path : std::nullopt);
+		(*g_firewall).tryWriteSettingsToFirewall(s, this->getAllBlockedAddresses(), this->getAppSettings().options.tunneling ? this->getAppSettings().config.tunneling_paths : std::set<std::filesystem::path>{});
 
 
 		// TODO if not failed
@@ -366,10 +353,10 @@ void Settings::toggleOptionTunneling() {
 	this->tryWriteSettingsToStorage();
 }
 
-void Settings::setConfigTunnelingPath(std::optional<std::filesystem::path> path)
+void Settings::setConfigTunnelingPaths(std::set<std::filesystem::path> paths)
 {
-	this->_dropship_app_settings.config.tunneling_path = path;
-	this->tryWriteSettingsToStorage();
+	this->_dropship_app_settings.config.tunneling_paths = std::move(paths);
+	this->tryWriteSettingsToStorage(true); // force write immediately
 }
 
 
@@ -402,21 +389,12 @@ void Settings::render() {
 
 		const auto game_open = (*g_window_watcher).isActive();
 
-		// pause config writes when game is open
-		if (game_open) {
-			//this->_waiting_for_config_write = true;
-		}
-
 		// trigger a write when game is closed
-		else
+		if (!game_open && this->_waiting_for_config_write)
 		{
-			if (this->_waiting_for_config_write)
-			{
-				this->_waiting_for_config_write = false;
-				this->tryWriteSettingsToStorage();
-			}
+		this->_waiting_for_config_write = false;
+			this->tryWriteSettingsToStorage(true);
 		}
-
 	}
 }
 

--- a/dropship/dropship/src/core/Settings.h
+++ b/dropship/dropship/src/core/Settings.h
@@ -37,7 +37,7 @@ namespace dropship::settings {
 
         struct _dropship_app_settings__config {
             std::set<std::string> blocked_endpoints;
-            std::optional<std::filesystem::path> tunneling_path;
+            std::set<std::filesystem::path> tunneling_paths;
         };
         _dropship_app_settings__config config;
     };
@@ -252,7 +252,7 @@ class Settings
         void addBlockedEndpoint(std::string endpoint_title);
         void removeBlockedEndpoint(std::string endpoint_title);
 
-        void setConfigTunnelingPath(std::optional<std::filesystem::path> path);
+        void setConfigTunnelingPaths(std::set<std::filesystem::path> paths);
 
         //void syncEndpoint(std::shared_ptr<Endpoint2> endpoint);
 

--- a/dropship/dropship/src/core/Tunneling.cpp
+++ b/dropship/dropship/src/core/Tunneling.cpp
@@ -19,22 +19,18 @@ namespace core::tunneling
 		if (!g_firewall) throw std::runtime_error("tunneling depends on g_firewall.");
 		if (!g_settings) throw std::runtime_error("tunneling depends on g_settings.");
 
-		/* if tunneling is enabled but no path defined, attempt automatic tunneling */
-		if (g_settings->getAppSettings().options.tunneling && !g_settings->getAppSettings().config.tunneling_path.has_value())
+		/* auto-detect a path only if no paths are saved yet */
+		if (g_settings->getAppSettings().config.tunneling_paths.empty())
 		{
 			const auto possible_paths = this->_queryFirewallForPossibleExePaths("Overwatch Application");
 
-			/* if there's only one good option, set path */
 			if (possible_paths.size() == 1)
 			{
-				const auto path = *(possible_paths.begin());
-				g_settings->setConfigTunnelingPath(std::make_optional(path));
+				std::set<std::filesystem::path> paths;
+				paths.insert(*possible_paths.begin());
+				g_settings->setConfigTunnelingPaths(std::move(paths));
 			}
-
-			/* otherwise open list */
 		}
-
-		//wprintf(g_settings->getAppSettings().config.tunneling_path.value_or(TEXT("NONE")).c_str());
 	}
 
 	std::set<std::string> core::tunneling::Tunneling::_queryFirewallForPossibleExePaths(std::string rule_name)
@@ -79,25 +75,31 @@ namespace core::tunneling
 		return result;
 	}
 
+	void core::tunneling::Tunneling::openExplainer()
+	{
+		this->_open_explainer_next_frame = true;
+	}
+
 	void core::tunneling::Tunneling::render()
 	{
 #ifdef _DEBUG
 		ImGui::Begin("debug");
 		if (ImGui::CollapsingHeader("tunneling", ImGuiTreeNodeFlags_None))
 		{
-			if (g_settings->getAppSettings().config.tunneling_path)
+			if (!g_settings->getAppSettings().config.tunneling_paths.empty())
 			{
-				ImGui::Text("path: %s", g_settings->getAppSettings().config.tunneling_path.value().c_str());
+				for (auto& p : g_settings->getAppSettings().config.tunneling_paths) {
+					ImGui::Text("path: %s", p.string().c_str());
+				}
 			}
 			else
 			{
-				ImGui::Text("PATH NOT SET");
+				ImGui::Text("NO PATHS SET");
 			}
 
 			{
 				if (ImGui::Button("PRINT UNIQUE", { ImGui::GetContentRegionAvail().x, 0 })) {
 					auto x = this->_queryFirewallForPossibleExePaths("Overwatch Application");
-
 					for (auto& f : x)
 					{
 						std::println("{}", f);
@@ -109,15 +111,9 @@ namespace core::tunneling
 				if (ImGui::Button("set tunneling path", { ImGui::GetContentRegionAvail().x, 0 })) {
 					auto path_wstring = util::win_filesystem::prompt_file();
 					if (path_wstring) {
-
-						//std::string path_utf8encoded = util::utf8::utf8_encode(path_wstring.value());
-						//std::println("{}", path_utf8encoded);
-
-						//wprintf(path_wstring.value().c_str());
-						//wprintf(util::utf8::utf8_decode(path_utf8encoded).c_str());
-
-						//g_settings->setConfigTunnelingPath(std::make_optional(path_utf8encoded));
-						g_settings->setConfigTunnelingPath(std::make_optional(path_wstring.value()));
+						auto paths = g_settings->getAppSettings().config.tunneling_paths;
+						paths.insert(path_wstring.value());
+						g_settings->setConfigTunnelingPaths(std::move(paths));
 					}
 					else
 					{
@@ -126,8 +122,8 @@ namespace core::tunneling
 				}
 				ImGui::SetItemTooltip("todo");
 
-				if (ImGui::Button("clear tunneling path", { ImGui::GetContentRegionAvail().x, 0 })) {
-					g_settings->setConfigTunnelingPath(std::nullopt);
+				if (ImGui::Button("clear all paths", { ImGui::GetContentRegionAvail().x, 0 })) {
+					g_settings->setConfigTunnelingPaths({});
 				}
 			}
 		}
@@ -143,7 +139,8 @@ namespace core::tunneling
 		static bool not_ignored { true };
 
 		const bool options_tunneling = g_settings->getAppSettings().options.tunneling;
-		const bool config_tunneling_path = g_settings->getAppSettings().config.tunneling_path.has_value();
+		const auto& current_paths = g_settings->getAppSettings().config.tunneling_paths;
+		const bool config_tunneling_paths_empty = current_paths.empty();
 
 		/* if tunneling popup was ignored, unignore if tunneling is toggled again*/
 		static bool prev_options_tunneling { options_tunneling };
@@ -154,7 +151,7 @@ namespace core::tunneling
 		prev_options_tunneling = options_tunneling;
 
 
-		const bool tunneling_active = options_tunneling && config_tunneling_path;
+		const bool tunneling_active = options_tunneling && !config_tunneling_paths_empty;
 
 		/* tunneling indicator */
 		{
@@ -179,15 +176,24 @@ namespace core::tunneling
 
 			ImGui::SetCursorScreenPos(original_pos);
 			ImGui::Dummy(width_text);
-			//ImGui::SetItemTooltip("Configure in options");
-			//if (ImGui::IsItemHovered()) ImGui::SetItemTooltip(util::utf8::utf8_encode(g_settings->getAppSettings().config.tunneling_path.value_or(TEXT("Configure in options"))).c_str());
-			if (ImGui::IsItemHovered()) ImGui::SetItemTooltip(g_settings->getAppSettings().config.tunneling_path ? g_settings->getAppSettings().config.tunneling_path.value().string().c_str() : "Configure in options");
+			if (ImGui::IsItemHovered()) ImGui::SetItemTooltip(current_paths.empty() ? "Configure in options" : current_paths.begin()->string().c_str());
 		}
 
-		/* open configuration if tunneling is enabled but there is no path defined */
-		if (options_tunneling && !config_tunneling_path && not_ignored && !ImGui::IsWindowAppearing())
+		/* open configuration if tunneling is enabled, no paths set, and not dismissed */
+		if (options_tunneling && config_tunneling_paths_empty && not_ignored && !ImGui::IsWindowAppearing())
 		{
 			ImGui::OpenPopup(popup_name.c_str());
+		}
+		/* open explainer on next frame when requested from Dashboard */
+		if (this->_open_explainer_next_frame)
+		{
+			ImGui::OpenPopup(popup_name.c_str());
+			this->_open_explainer_next_frame = false;
+		}
+		/* reset not_ignored when paths become non-empty (so next time they clear, popup re-opens) */
+		if (!config_tunneling_paths_empty)
+		{
+			not_ignored = true;
 		}
 
 		/* configuration popup */
@@ -195,7 +201,7 @@ namespace core::tunneling
 			ImVec2 center = ImGui::GetWindowViewport()->GetCenter();
 			ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
 			ImGui::SetNextWindowSize({ 400, 0 });
-			if (ImGui::BeginPopupModal(popup_name.c_str(), &not_ignored, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_AlwaysAutoResize))
+			if (ImGui::BeginPopupModal(popup_name.c_str(), NULL, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_AlwaysAutoResize))
 			{
 				ImGui::TextWrapped("Tunneling allows you to block servers per-application instead of globally");
 				ImGui::Spacing();
@@ -206,7 +212,6 @@ namespace core::tunneling
 				const auto n_buttons{ 2 };
 				const ImVec2 button{ (ImGui::GetContentRegionAvail().x - ((style.ItemSpacing.x / 1.f) * (n_buttons - 1))) / n_buttons, 0 };
 
-				/* choice 00 */
 				ImGui::PushStyleColor(ImGuiCol_Text, { 0, 0, 0, 0.5f });
 				ImGui::PushStyleColor(ImGuiCol_Button, { 0, 0, 0, 0.0f });
 				ImGui::PushStyleColor(ImGuiCol_ButtonHovered, { 0, 0, 0, 0.04f });
@@ -214,132 +219,143 @@ namespace core::tunneling
 				{
 					if (ImGui::Button("Skip for now", button)) {
 						not_ignored = false;
+						ImGui::CloseCurrentPopup();
 					}
 				}
 				ImGui::PopStyleColor(4);
 
 				ImGui::SameLine();
 
-				/* choice 02 */
 				if (ImGui::Button("Continue", button)) {
-					ImGui::OpenPopup(popup_name_continue.c_str());
+					not_ignored = false;
+					ImGui::CloseCurrentPopup();
+					this->_open_path_picker_next_frame = true;
 				}
 
-				/* configuration popup continued (part 2) */
-				{
-					ImVec2 center = ImGui::GetWindowViewport()->GetCenter();
-					ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
-					ImGui::SetNextWindowSize({ 666, 0 });
-					if (ImGui::BeginPopupModal(popup_name_continue.c_str(), &not_ignored, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_AlwaysAutoResize))
-					{
+				ImGui::EndPopup();
+			}
+		}
 
-						static std::optional<std::string> error_text{ std::nullopt };
+		/* open path picker on next frame after Continue */
+		if (this->_open_path_picker_next_frame)
+		{
+			ImGui::OpenPopup(popup_name_continue.c_str());
+			this->_open_path_picker_next_frame = false;
+		}
 
-						static auto possible_paths{ this->_queryFirewallForPossibleExePaths("Overwatch Application") };
-						static int selected{ possible_paths.size() > 0 ? 0 : -1 };
+		/* path picker popup (separate, not nested) */
+		{
+			ImVec2 center = ImGui::GetWindowViewport()->GetCenter();
+			ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+			ImGui::SetNextWindowSize({ 750, 0 });
+			if (ImGui::BeginPopupModal(popup_name_continue.c_str(), NULL, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_AlwaysAutoResize))
+			{
+				static std::set<std::string> possible_paths;
+				static std::set<std::string> auto_detected_paths;
+				static int selected;
+				if (ImGui::IsWindowAppearing()) {
+					auto_detected_paths = Tunneling::_queryFirewallForPossibleExePaths("Overwatch Application");
+					possible_paths = auto_detected_paths;
+					for (auto& p : g_settings->getAppSettings().config.tunneling_paths) {
+						possible_paths.insert(p.string());
+					}
+					selected = possible_paths.size() > 0 ? 0 : -1;
+				}
 
-						//ImGui::Text("selected %d", selected);
+				ImGui::TextWrapped("Select the Overwatch.exe to use for per-application blocking.");
+				ImGui::Spacing();
 
-						ImGui::TextWrapped("Please choose the correct Overwatch.exe from your computer's filesystem.");
+				int n = 0;
+				for (auto it = possible_paths.begin(); it != possible_paths.end();) {
+					auto& p = *it;
+					const ImU32 color = (ImU32)ImColor::HSV(1.0f - ((n + 1) / 32.0f), 0.4f, 1.0f, 1.0f);
+					const ImU32 color_hover = (ImU32)ImColor::HSV(1.0f - ((n + 1) / 32.0f), 0.3f, 1.0f, 1.0f);
+					const ImU32 color_secondary_faded = (ImU32)ImColor::HSV(1.0f - ((n + 1) / 32.0f), 0.2f, 1.0f, 0.4f * 1.0f);
 
-						ImGui::Spacing();
+					ImGui::PushStyleColor(ImGuiCol_Header, color_hover);
+					ImGui::PushStyleColor(ImGuiCol_HeaderHovered, color_secondary_faded);
+					ImGui::PushStyleColor(ImGuiCol_HeaderActive, color);
 
-						int n = 0;
-						for (auto& p : possible_paths) {
-
-							const ImU32 color = (ImU32)ImColor::HSV(1.0f - ((n + 1) / 32.0f), 0.4f, 1.0f, 1.0f);
-							const ImU32 color_hover = (ImU32)ImColor::HSV(1.0f - ((n + 1) / 32.0f), 0.3f, 1.0f, 1.0f);
-							const ImU32 color_secondary_faded = (ImU32)ImColor::HSV(1.0f - ((n + 1) / 32.0f), 0.2f, 1.0f, 0.4f * 1.0f);
-							static const auto transparent = ImVec4(0.f, 0.f, 0.f, 0.f);
-
-							ImGui::PushStyleColor(ImGuiCol_Header, color_hover);
-							ImGui::PushStyleColor(ImGuiCol_HeaderHovered, color_secondary_faded);
-							ImGui::PushStyleColor(ImGuiCol_HeaderActive, color);
-
-							//ImGui::Bullet(); ImGui::SameLine(); ImGui::Spacing(); ImGui::SameLine();
-							if (ImGui::Selectable(p.c_str(), selected == n, ImGuiSelectableFlags_DontClosePopups))
+					if (ImGui::Selectable(p.c_str(), selected == n, ImGuiSelectableFlags_DontClosePopups, ImVec2(ImGui::GetContentRegionAvail().x - 110, 0)))
 							{
 								selected = n;
 							}
 							if (selected == n && ImGui::IsItemHovered()) ImGui::SetItemTooltip(p.c_str());
-							n++;
-
 							ImGui::PopStyleColor(3);
-						}
-
-						//std::println("file exists: {}", std::filesystem::exists("S:\\Overwatch\\_retail_\\Overwatch.exe") ? "true" : "false");
-						//std::println("file exists: {}", std::filesystem::exists("S:\\overwatch\\_retail_\\overwatch.exe") ? "true" : "false");
-
-						ImGui::Spacing();
-						//wprintf(L"C:\\Users\\stormy\\AppData\\Local\\Temp\\べてのファ 況ロ");
-
-						if (ImGui::Button(possible_paths.size() > 0 ? "Add another .." : "Add path ..", ImVec2(ImGui::GetContentRegionAvail().x, 0)))
-						{
-							auto path = util::win_filesystem::prompt_file();
-							if (path) {
-
-								std::println("{}", path.value().string());
-
-								//wprintf(path_wstring.value().c_str());
-								//wprintf(util::utf8::utf8_decode(path_utf8encoded).c_str());
-
-								//g_settings->setConfigTunnelingPath(std::make_optional(path_utf8encoded));
-
-								int size_before = possible_paths.size();
-								possible_paths.insert(path.value().string());
-								if (possible_paths.size() != size_before)
-								{
-									selected = std::max(0, (int)possible_paths.size() - 1);
-								};
-								error_text.reset();
-							}
-							else
-							{
-								error_text = std::make_optional("Adding another file didn't work.");
-							}
-						}
-
-						if (error_text)
-						{
-							ImGui::PushStyleColor(ImGuiCol_Text, (ImU32)ImColor::HSV(1.0f - ((0 + 1) / 32.0f), 0.5f, 1.0f, 1.0f));
-							//ImGui::Indent();
-							ImGui::TextUnformatted(error_text.value().c_str());
-							ImGui::PopStyleColor();
-						}
-
-						ImGui::Spacing();
-
-						{
-							const auto n_buttons{ 2 };
-							const ImVec2 button{ (ImGui::GetContentRegionAvail().x - ((style.ItemSpacing.x / 1.f) * (n_buttons - 1))) / n_buttons, 0 };
-
-							/* choice 00 */
-							ImGui::PushStyleColor(ImGuiCol_Text, { 0, 0, 0, 0.5f });
-							ImGui::PushStyleColor(ImGuiCol_Button, { 0, 0, 0, 0.0f });
-							ImGui::PushStyleColor(ImGuiCol_ButtonHovered, { 0, 0, 0, 0.04f });
-							ImGui::PushStyleColor(ImGuiCol_ButtonActive, { 0, 0, 0, 0.09f });
-							{
-								if (ImGui::Button("Skip for now", button)) {
-									not_ignored = false;
-								}
-							}
-							ImGui::PopStyleColor(4);
 
 							ImGui::SameLine();
 
-							/* choice 02 */
+							ImGui::PushStyleColor(ImGuiCol_Text, color);
+							ImGui::PushStyleColor(ImGuiCol_Button, { 0, 0, 0, 0.0f });
+							ImGui::PushStyleColor(ImGuiCol_ButtonHovered, { 0, 0, 0, 0.1f });
+							ImGui::PushStyleColor(ImGuiCol_ButtonActive, { 0, 0, 0, 0.2f });
 
-							if (selected == -1) ImGui::BeginDisabled();
-							if (ImGui::Button("Done", button)) {
-
-								g_settings->setConfigTunnelingPath(*std::next(possible_paths.begin(), selected));
-								not_ignored = false; // FIXME
-							}
-							if (selected == -1) ImGui::EndDisabled();
-						}
-
-						ImGui::EndPopup();
+							bool is_auto = (auto_detected_paths.find(p) != auto_detected_paths.end());
+							if (is_auto) ImGui::BeginDisabled();
+							if (ImGui::Button(std::format("Remove##{}", n).c_str(), { 100, 0 })) {
+						auto paths_new = g_settings->getAppSettings().config.tunneling_paths;
+						paths_new.erase(std::filesystem::path(p));
+						g_settings->setConfigTunnelingPaths(std::move(paths_new));
+						possible_paths.erase(it++);
+						selected = possible_paths.size() > 0 ? 0 : -1;
+						continue;
 					}
+					if (is_auto) {
+						ImGui::EndDisabled();
+						ImGui::SetItemTooltip("Auto-detected path — use \"Add another\" to save a custom path");
+					}
+					ImGui::PopStyleColor(4);
+
+					++it;
+					n++;
+				}
+
+				ImGui::Spacing();
+
+				if (ImGui::Button(possible_paths.size() > 0 ? "Add another .." : "Add path ..", ImVec2(ImGui::GetContentRegionAvail().x, 0)))
+				{
+					auto path = util::win_filesystem::prompt_file();
+					if (path) {
+						auto paths_new = g_settings->getAppSettings().config.tunneling_paths;
+						paths_new.insert(path.value());
+						g_settings->setConfigTunnelingPaths(std::move(paths_new));
+						possible_paths.insert(path.value().string());
+						auto it2 = possible_paths.find(path.value().string());
+						selected = (int)std::distance(possible_paths.begin(), it2);
+					}
+				}
+
+				ImGui::Spacing();
+
+				{
+					const auto n_buttons{ 2 };
+					const ImVec2 button{ (ImGui::GetContentRegionAvail().x - ((style.ItemSpacing.x / 1.f) * (n_buttons - 1))) / n_buttons, 0 };
+
+					ImGui::PushStyleColor(ImGuiCol_Text, { 0, 0, 0, 0.5f });
+					ImGui::PushStyleColor(ImGuiCol_Button, { 0, 0, 0, 0.0f });
+					ImGui::PushStyleColor(ImGuiCol_ButtonHovered, { 0, 0, 0, 0.04f });
+					ImGui::PushStyleColor(ImGuiCol_ButtonActive, { 0, 0, 0, 0.09f });
+					{
+						if (ImGui::Button("Skip for now", button)) {
+							not_ignored = false;
+							ImGui::CloseCurrentPopup();
+						}
+					}
+					ImGui::PopStyleColor(4);
+
+					ImGui::SameLine();
+
+					if (selected == -1) ImGui::BeginDisabled();
+					if (ImGui::Button("Done", button)) {
+						std::set<std::filesystem::path> paths;
+						for (auto& p : possible_paths) {
+							paths.insert(std::filesystem::path(p));
+						}
+						g_settings->setConfigTunnelingPaths(std::move(paths));
+						not_ignored = false;
+						ImGui::CloseCurrentPopup();
+					}
+					if (selected == -1) ImGui::EndDisabled();
 				}
 
 				ImGui::EndPopup();

--- a/dropship/dropship/src/core/Tunneling.h
+++ b/dropship/dropship/src/core/Tunneling.h
@@ -14,9 +14,13 @@ namespace core::tunneling
 		public:
 			Tunneling();
 			void render();
+			void openExplainer();
 
 		private:
 			static std::set<std::string> _queryFirewallForPossibleExePaths(std::string rule_name /* = "Overwatch Application" */);
+			bool _open_path_picker_next_frame = false;
+			bool _open_explainer_next_frame = false;
+
 
 	};
 

--- a/dropship/dropship/src/util/watcher/window.cpp
+++ b/dropship/dropship/src/util/watcher/window.cpp
@@ -8,6 +8,7 @@ namespace util::watcher::window {
         std::optional<::HWND> match = std::nullopt;
 
         for (::HWND hwnd = ::GetTopWindow(NULL); hwnd != NULL; hwnd = GetNextWindow(hwnd, GW_HWNDNEXT)) {
+			if (!::IsWindowVisible(hwnd)) continue;
             int length = GetWindowTextLength(hwnd);
             if (length == 0) continue;
 
@@ -15,12 +16,29 @@ namespace util::watcher::window {
             {
                 ::GetWindowTextA(hwnd, title, length + 1);
 
-                if (strcmp(title, window_name.c_str()) == 0)
-                {
-                    // std::cout << "HWND: " << hwnd << " Title: " << s_title << std::endl;
-                    match = std::make_optional<::HWND>(hwnd);
-                    break;
-                }
+				// Substring match in case window title includes version/extra text
+				if (std::string_view(title).find(window_name) != std::string_view::npos)
+				{
+					// Verify process exe name also contains "Overwatch" to avoid false positives
+					DWORD pid = 0;
+					::GetWindowThreadProcessId(hwnd, &pid);
+					if (pid) {
+						HANDLE hProc = ::OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+						if (hProc) {
+							char exePath[MAX_PATH];
+							DWORD exeSize = MAX_PATH;
+							if (::QueryFullProcessImageNameA(hProc, 0, exePath, &exeSize)) {
+								std::string_view exe(exePath, exeSize);
+								if (exe.find("Overwatch") != std::string_view::npos ||
+									exe.find("overwatch") != std::string_view::npos) {
+									match = std::make_optional<::HWND>(hwnd);
+								}
+							}
+							::CloseHandle(hProc);
+						}
+					}
+					if (match) break;
+				}
             }
             delete[] title;
         }

--- a/dropship/dropship/src/util/win/win_filesystem/file_picker.cpp
+++ b/dropship/dropship/src/util/win/win_filesystem/file_picker.cpp
@@ -37,11 +37,9 @@ namespace util::win_filesystem {
 
 		OPENFILENAME ofn = {};
 		ofn.lStructSize = sizeof(OPENFILENAME);
-		if (g_hwnd != nullptr) ofn.hwndOwner = g_hwnd;
-		//ofn.lpstrFilter = TEXT("実況ログ(*.jkl;*.xml)\0*.jkl;*.xml\0すべてのファイル\0*.*\0");
-		//ofn.lpstrFilter = TEXT("Overwatch.exe\0Overwatch.exe\0all files\0*.*\0");
+		// Don't use hidden g_hwnd as owner — it can cause GetOpenFileName to fail
+		ofn.hwndOwner = NULL;
 		ofn.lpstrFilter = TEXT("Overwatch.exe\0Overwatch.exe\0");
-		//ofn.lpstrTitle = TEXT("ファイルを開く");
 		ofn.lpstrTitle = TEXT("please find \"Overwatch.exe\"");
 		ofn.Flags = OFN_HIDEREADONLY | OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR | OFN_EXPLORER;
 		ofn.lpstrFile = path;
@@ -53,6 +51,8 @@ namespace util::win_filesystem {
 		}
 		else
 		{
+			DWORD err = CommDlgExtendedError();
+			if (err) printf("GetOpenFileName error: %lu\n", err);
 			return std::nullopt;
 		}
 

--- a/dropship/dropship/src/util/win/win_firewall/windows_firewall.cpp
+++ b/dropship/dropship/src/util/win/win_firewall/windows_firewall.cpp
@@ -174,6 +174,27 @@ namespace util::win_firewall {
 
         predicate(pFwRules);
     }
+
+    void removeAllRulesInGroup(std::string _target_groupName) {
+        std::vector<CComBSTR> rule_names;
+        forFirewallRulesInGroup(_target_groupName, [&rule_names](const CComPtr<INetFwRule>& FwRule, const CComPtr<INetFwRules>&) {
+            CComBSTR name;
+            if (SUCCEEDED(FwRule->get_Name(&name)) && name)
+            {
+                rule_names.push_back(CComBSTR(name));
+            }
+        });
+
+        if (rule_names.empty()) return;
+
+        firewallRulesPredicate([&rule_names](const CComPtr<INetFwRules>& FwRules) {
+            for (auto& name : rule_names) {
+                if (FAILED(FwRules->Remove(name))) {
+                    wprintf(L"Failed to remove rule\n");
+                }
+            }
+        });
+    }
 }
 
 

--- a/dropship/dropship/src/util/win/win_firewall/windows_firewall.h
+++ b/dropship/dropship/src/util/win/win_firewall/windows_firewall.h
@@ -19,8 +19,8 @@
     !! QUARANTINE ZONE !!
 
     there is a lot of win32 stuff in this one file.
-      • the official windows examples have massive memory leaks and are bad.
-      • thus one uses ccomptr to avoid memory leaks: https://github.com/microsoft/Windows-classic-samples/blob/44d192fd7ec6f2422b7d023891c5f805ada2c811/Samples/Win7Samples/security/windowsfirewall/enumeratefirewallrules/EnumerateFirewallRules.cpp
+      ï¿½ the official windows examples have massive memory leaks and are bad.
+      ï¿½ thus one uses ccomptr to avoid memory leaks: https://github.com/microsoft/Windows-classic-samples/blob/44d192fd7ec6f2422b7d023891c5f805ada2c811/Samples/Win7Samples/security/windowsfirewall/enumeratefirewallrules/EnumerateFirewallRules.cpp
 
 */
 
@@ -31,4 +31,7 @@ namespace util::win_firewall {
     void forFirewallRulesWithName(std::string _target_ruleName, std::function<void(const CComPtr<INetFwRule>&, const CComPtr<INetFwRules>&)> predicate);
 
     void firewallRulesPredicate(std::function<void(const CComPtr<INetFwRules>&)> predicate);
+
+    /* safely removes all rules in a group (collects names first, then removes) */
+    void removeAllRulesInGroup(std::string _target_groupName);
 }


### PR DESCRIPTION
The program looked interesting but was giving me some options. Seemingly being convinced the game was running, even when not. But also not storing settings after restarting it, or retaining the custom path for the Overwatch executable. (the auto detected one was the wrong one). 

The settings stored in the firewall rule Description field were being silently truncated due to C-string APIs stopping at null bytes in the MessagePack binary data. This caused all preferences to reset on every restart and made editing tunneling paths unreliable.

Changes:
- Read and write the firewall rule Description as a binary blob (SysAllocStringByteLen / SysStringByteLen) instead of a C-string
- Serialize tunneling paths to/from JSON as plain strings to avoid std::filesystem::path wchar_t encoding issues
- Store a set of paths instead of a single optional path
- Create one outbound block rule per configured path
- Detect active Overwatch windows by process name rather than exact window title match, preventing false positives
- Allow the user to add and remove paths in the tunneling selector; auto-detected paths are shown but cannot be removed